### PR TITLE
Update base image tag in Prow jobs

### DIFF
--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/amazon-eks-pod-identity-webhook-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: charts-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/athens-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-periodics.yaml
@@ -38,7 +38,7 @@ periodics:
     serviceaccountName: periodics-build-account
     containers:
     - name: build-container
-      image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+      image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
       command:
       - bash
       - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-postsubmits.yaml
@@ -40,7 +40,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/eks-distro-base-presubmits.yaml
@@ -38,7 +38,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/github-exporter-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
     spec:
       serviceaccountName: charts-build-account
       containers:
-      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/helm-chart-presubmits.yaml
@@ -28,7 +28,7 @@ presubmits:
     spec:
       serviceaccountName: presubmits-build-account
       containers:
-      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-alertmanager-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
     spec:
       serviceaccountName: charts-build-account
       containers:
-      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-helm-chart-presubmits.yaml
@@ -28,7 +28,7 @@ presubmits:
     spec:
       serviceaccountName: presubmits-build-account
       containers:
-      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-postsubmit.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-postsubmit.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/prometheus-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
+++ b/jobs/aws/eks-distro-build-tooling/release-tooling-presubmits.yaml
@@ -28,7 +28,7 @@ presubmits:
     spec:
       serviceaccountName: presubmits-build-account
       containers:
-      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
+++ b/jobs/aws/eks-distro-prow-jobs/prowjobs-lint-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
+++ b/jobs/aws/eks-distro/aws-iam-authenticator-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/cni-postsubmits.yaml
+++ b/jobs/aws/eks-distro/cni-postsubmits.yaml
@@ -30,7 +30,7 @@ postsubmits:
     spec:
       serviceaccountName: postsubmits-build-account
       containers:
-      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/cni-presubmits.yaml
+++ b/jobs/aws/eks-distro/cni-presubmits.yaml
@@ -28,7 +28,7 @@ presubmits:
     spec:
       serviceaccountName: presubmits-build-account
       containers:
-      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+      - image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/coredns-postsubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/coredns-presubmits.yaml
+++ b/jobs/aws/eks-distro/coredns-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/docs-postsubmit.yaml
+++ b/jobs/aws/eks-distro/docs-postsubmit.yaml
@@ -31,7 +31,7 @@ postsubmits:
       serviceaccountName: docs-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         env:
         - name: AWS_STS_REGIONAL_ENDPOINTS
           value: regional

--- a/jobs/aws/eks-distro/docs-presubmit.yaml
+++ b/jobs/aws/eks-distro/docs-presubmit.yaml
@@ -29,7 +29,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/etcd-postsubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/etcd-presubmits.yaml
+++ b/jobs/aws/eks-distro/etcd-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-attacher-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-attacher-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-provisioner-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-resizer-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-resizer-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
+++ b/jobs/aws/eks-distro/external-snapshotter-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-postsubmits.yaml
@@ -34,7 +34,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-1-18-presubmits.yaml
@@ -32,7 +32,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
+++ b/jobs/aws/eks-distro/kubernetes-release-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
+++ b/jobs/aws/eks-distro/livenessprobe-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/main-presubmits.yaml
+++ b/jobs/aws/eks-distro/main-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/metrics-server-presubmits.yaml
+++ b/jobs/aws/eks-distro/metrics-server-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - sh
         - -c

--- a/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-postsubmits.yaml
@@ -33,7 +33,7 @@ postsubmits:
       serviceaccountName: postsubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c

--- a/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
+++ b/jobs/aws/eks-distro/node-driver-registrar-presubmits.yaml
@@ -31,7 +31,7 @@ presubmits:
       serviceaccountName: presubmits-build-account
       containers:
       - name: build-container
-        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:59e01a3960ed4b4e0b84b8f5e0ea9ddc1b99f1cb
+        image: 326475626674.dkr.ecr.us-west-2.amazonaws.com/eks-distro/builder:149f88c4b4662c3b6e02eef9f37ac47746a709a4
         command:
         - bash
         - -c


### PR DESCRIPTION
This PR updates the base image tag in all the prowjobs with the tag of the most recently built builder-base image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.